### PR TITLE
Correct Statseeker module to use InventoryInterface object

### DIFF
--- a/src/network_ops_dashboard/inventory/forms.py
+++ b/src/network_ops_dashboard/inventory/forms.py
@@ -29,7 +29,7 @@ class InventoryForm(forms.ModelForm):
     port_rest = forms.CharField(label="Port (REST):", initial='443')
     port_netc = forms.CharField(label="Port (NETCONF):", initial='830')
     port_gnmi = forms.CharField(label="Port (gNMI):", initial='9339')
-    device_tag = forms.ModelMultipleChoiceField(label="Device Tags:", queryset=DeviceTag.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select'}), required=False)
+    device_tag = forms.ModelMultipleChoiceField(label="Device Tags:", queryset=DeviceTag.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select', "data-placeholder": "Select DeviceTags"}), required=False)
     creds_ssh = forms.ModelChoiceField(label="SSH Credential:", queryset=NetworkCredential.objects.all(), required=False)
     creds_rest = forms.ModelChoiceField(label="REST Credential:", queryset=NetworkCredential.objects.all(), required=False)
 

--- a/src/network_ops_dashboard/inventory/models.py
+++ b/src/network_ops_dashboard/inventory/models.py
@@ -170,13 +170,6 @@ class Inventory(models.Model):
     last_backup_at = models.DateTimeField(null=True, blank=True)
     discovery_source = models.CharField(max_length=64, blank=True, default="")
     sw_version = models.CharField(max_length=128, blank=True, default="")
-    # Priority/Tracked Interfaces
-    priority_interfaces = models.JSONField(default=list, blank=True, null=True)
-    # stores ["Ethernet1/1", "Ethernet2/43", "mgmt0"]
-    def get_priority_interfaces(self):
-        return [k.strip() for k in (self.priority_interfaces or "").split(",") if k.strip()]
-    def set_priority_interfaces(self, items):
-        self.priority_interfaces = ",".join([str(i).strip() for i in (items or [])])
     # Flex Field
     extra = models.JSONField(blank=True, default=dict)
 

--- a/src/network_ops_dashboard/inventory/views.py
+++ b/src/network_ops_dashboard/inventory/views.py
@@ -33,6 +33,9 @@ def inventory_home(request):
 
 @login_required
 def inventory_edit_modal(request, pk):
+    if not pk:
+        return redirect("inventory_home")
+    
     device = get_object_or_404(Inventory, pk=pk)
 
     if request.method == "POST":
@@ -121,7 +124,6 @@ def inventory_edit_modal(request, pk):
         },
     )
 
-
 @login_required(login_url='/accounts/login/')
 def inventory_add_modal(request):
     if request.method == "POST":
@@ -131,7 +133,9 @@ def inventory_add_modal(request):
             return HttpResponse('<script>window.location.reload()</script>')
     else:
         form = InventoryForm()
-    return render(request, "network_ops_dashboard/inventory/_inventory_form.html", {"form": form, "device": None})
+    context = {"form": form}
+    context["device"] = None
+    return render(request, "network_ops_dashboard/inventory/_inventory_form.html", context)
 
 @login_required(login_url='/accounts/login/')
 def inventory_delete_modal(request, pk):

--- a/src/network_ops_dashboard/notices/statseeker/forms.py
+++ b/src/network_ops_dashboard/notices/statseeker/forms.py
@@ -30,7 +30,7 @@ class StatseekerSettingsForm(forms.ModelForm):
             "credential": forms.Select(attrs={"class": "form-select"}),
             "base_url": forms.TextInput(attrs={"class": "form-control", "placeholder": "https://..."}),
             "verify_ssl": forms.CheckboxInput(attrs={"class": "form-check-input"}),
-            "tracked_devices": forms.SelectMultiple(attrs={"class": "form-select", "size": 8}),
+            "tracked_devices": forms.SelectMultiple(attrs={"class": "form-select", "data-placeholder": "Select Devices", "size": 8}),
             "top_n": forms.NumberInput(attrs={"class": "form-control", "min": 1}),
             "min_interval_minutes": forms.NumberInput(attrs={"class": "form-control", "min": 1}),
             "error_pct_threshold": forms.NumberInput(attrs={"class": "form-control", "min": 0, "step": "0.1"}),
@@ -45,7 +45,7 @@ class StatseekerSettingsForm(forms.ModelForm):
             self.fields["credential"].queryset = NetworkCredential.objects.order_by("name")
         except Exception:
             pass
-        # If you’d like to pre-filter available devices, do it here:
+        
         self.fields["tracked_devices"].queryset = Inventory.objects.all().order_by("name")
-        self.fields["tracked_devices"].help_text = "Choose devices to watch. Their priority_interfaces field determines which interfaces to evaluate for IF_DOWN/IF_ERRORS."
+        self.fields["tracked_devices"].help_text = "Choose devices to watch. Their tracked interfaces determines which to evaluate for IF_DOWN/IF_ERRORS."
 

--- a/src/network_ops_dashboard/notices/statseeker/scripts/services.py
+++ b/src/network_ops_dashboard/notices/statseeker/scripts/services.py
@@ -9,12 +9,20 @@ from network_ops_dashboard.inventory.models import Inventory
 logger = logging.getLogger('network_ops_dashboard.notices.statseeker')
 
 def _tracked_interfaces(inv: Inventory):
-    # Inventory.priority_interfaces is a comma-separated string.
+    """
+    Return a list of interface names that are marked as priority
+    for a given Inventory object.
+    """
     try:
-        return inv.get_priority_interfaces()
-    except Exception:
-        # fallback if needed
-        s = (inv.priority_interfaces or "").strip()
+        # use the related_name defined in InventoryInterface.device FK
+        return list(
+            inv.interfaces.filter(is_priority=True)
+            .order_by("rack", "slot", "subslot", "port", "name")
+            .values_list("name", flat=True)
+        )
+    except Exception as e:
+        # fallback for legacy data or schema mismatch
+        s = getattr(inv, "priority_interfaces", "") or ""
         return [p.strip() for p in s.split(",") if p.strip()]
 
 def _SScookie(base, auth, verifySSL):

--- a/src/network_ops_dashboard/reports/changes/views.py
+++ b/src/network_ops_dashboard/reports/changes/views.py
@@ -48,6 +48,8 @@ def changes(request):
     groups = (CompanyChanges.objects
               .exclude(group__isnull=True).exclude(group__exact="")
               .order_by('group').values_list('group', flat=True).distinct())
+    
+    sites = Site.objects.all().order_by('name')
 
     return render(
         request,
@@ -59,6 +61,7 @@ def changes(request):
             'locations': locations,
             'teams': teams,
             'groups': groups,
+            'sites': sites,
         }
     )
 
@@ -70,9 +73,6 @@ def changes_update(request):
 @staff_member_required
 @require_POST
 def save_changes_settings(request):
-    import json
-    from network_ops_dashboard.inventory.models import Site
-
     s, _ = CompanyChangesSettings.objects.get_or_create(pk=1)
 
     s.changes_folder = request.POST.get("changes_folder", s.changes_folder or "")

--- a/src/network_ops_dashboard/sitesettings/forms.py
+++ b/src/network_ops_dashboard/sitesettings/forms.py
@@ -10,8 +10,8 @@ class SiteSettingsForm(forms.ModelForm):
         fields = ('company', 'teamname', 'websites', 'publicscripts', 'companylogo')
     company = forms.CharField(label="Company Name:", required=True)
     teamname = forms.CharField(label="Team Name:", required=True)
-    websites = forms.ModelMultipleChoiceField(label="Home Site Websites:", help_text="Websites show up on main public page.", queryset=SiteSettingsWebsite.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select'}), required=False)
-    publicscripts = forms.ModelMultipleChoiceField(label="Public Script Page Websites:", help_text="Websites show up public scripts page.", queryset=SiteSettingsWebsite.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select'}), required=False)
+    websites = forms.ModelMultipleChoiceField(label="Home Site Websites:", help_text="Websites show up on main public page.", queryset=SiteSettingsWebsite.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select', "data-placeholder": "Select Websites"}), required=False)
+    publicscripts = forms.ModelMultipleChoiceField(label="Public Script Page Websites:", help_text="Websites show up public scripts page.", queryset=SiteSettingsWebsite.objects.all(), widget=forms.SelectMultiple(attrs={'class': 'form-select', "data-placeholder": "Select Websites"}), required=False)
     companylogo = forms.ImageField()
 
 class SiteSettingsWebsiteForm(forms.ModelForm):

--- a/src/network_ops_dashboard/templates/network_ops_dashboard/base.html
+++ b/src/network_ops_dashboard/templates/network_ops_dashboard/base.html
@@ -30,9 +30,11 @@
                 {% endif %}
                 <link rel="stylesheet" href="{% static 'css/base.css' %}">
                 <link rel="stylesheet" href="{% static 'css/style.css' %}">
-                <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+                <link href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
+                <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
                 <script src="https://bootswatch.com/_vendor/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
                 <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+                <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
                 <script type="text/javascript">
                         function getDocHeight(doc) {
                                 doc = doc || document;
@@ -222,7 +224,52 @@
                         </div>
                         {% endif %}
 
+
+
                 {% block content %}
                 {% endblock %}
+                <script>
+                        (function() {
+                          function initTomSelects(root=document) {
+                            const selects = root.querySelectorAll('select[multiple]:not([data-ts-init])');
+                            selects.forEach(function(el) {
+                              el.setAttribute('data-ts-init', 'true');
+                              if (typeof TomSelect === 'undefined') {
+                                console.error('TomSelect library not loaded!');
+                                return;
+                              }
+                              console.log('Initializing Tom Select for', el.name);
+                              new TomSelect(el, {
+                                plugins: ['remove_button'],
+                                closeAfterSelect: false,
+                                hideSelected: false,
+                                maxItems: null,
+                                persist: false,
+                                render: {
+                                  option: (data, escape) => `<div>${escape(data.text)}</div>`,
+                                  item: (data, escape) => `<div>${escape(data.text)}</div>`
+                                }
+                              });
+                            });
+                          }
+                        
+                          // Run once when DOM is ready
+                          document.addEventListener('DOMContentLoaded', function() {
+                            initTomSelects();
+                          });
+                        
+                          // Re-run after any HTMX swap (modals, partials, etc)
+                          document.body.addEventListener('htmx:afterSwap', function(e) {
+                            initTomSelects(e.target);
+                          });
+                        
+                          // Safety net: retry a few times in case of late load
+                          let attempts = 0;
+                          const interval = setInterval(() => {
+                            initTomSelects();
+                            if (++attempts > 10) clearInterval(interval);
+                          }, 500);
+                        })();
+                        </script>
         </body>
 </html>

--- a/src/network_ops_dashboard/templates/network_ops_dashboard/dashboard.html
+++ b/src/network_ops_dashboard/templates/network_ops_dashboard/dashboard.html
@@ -352,12 +352,13 @@
                       {{ statseeker_form.base_url }}
                     </div>
                   </div>
-            
                   <div class="row g-3 mt-1">
                     <div class="col-md-6">
                       <label class="form-label">{{ statseeker_form.tracked_devices.label }}</label>
                       {{ statseeker_form.tracked_devices }}
-                      <div class="form-text">Set device <code>priority_interfaces</code> for IF_DOWN/IF_ERRORS.</div>
+                      <div class="form-text text-muted small">
+                        Select device(s) whose tracked interfaces will be monitored for link status and errors.
+                      </div>
                     </div>
                     <div class="col-md-3">
                       <label class="form-label">{{ statseeker_form.top_n.label }}</label>
@@ -368,7 +369,6 @@
                       {{ statseeker_form.verify_ssl }}
                     </div>
                   </div>
-            
                   <div class="row g-3 mt-1">
                     <div class="col-md-4">
                       <label class="form-label">{{ statseeker_form.error_pct_threshold.label }}</label>

--- a/src/network_ops_dashboard/templates/network_ops_dashboard/reports/changes/home.html
+++ b/src/network_ops_dashboard/templates/network_ops_dashboard/reports/changes/home.html
@@ -122,7 +122,7 @@
 
           <div class="col-12" id="sitesMultiWrap" {% if not settings_obj.use_sites_for_locations %}style="display:none"{% endif %}>
             <label class="form-label">Limit to specific Sites (optional)</label>
-            <select name="sites_to_filter" class="form-select" multiple size="8">
+            <select name="sites_to_filter" class="form-select" multiple size="8" data-placeholder="Select Sites">
               {% for site in sites %}
                 <option value="{{ site.pk }}"
                   {% if site in settings_obj.sites_to_filter.all %}selected{% endif %}>
@@ -131,7 +131,7 @@
               {% endfor %}
             </select>
             <div class="form-text">
-              Hold Ctrl/Cmd to select multiple. If none selected, all Sites are considered valid.
+              If none selected, all Sites are considered valid.
             </div>
           </div>
 


### PR DESCRIPTION
(fix): Correct Statseeker module to use InventoryInterface object for tracked/priority interfaces. Remove priority_interfaces field from Inventory object. Utilize TomSelect for select fields and modify data placeholder in places that use multi select fields.